### PR TITLE
fix(DataLoader): you couldn't reuse Dataloaders before to load different splits

### DIFF
--- a/src/mopi/data/dataloader.py
+++ b/src/mopi/data/dataloader.py
@@ -49,8 +49,8 @@ class HuggingfaceDataLoader(DataLoader):
         self.name = name
 
     def load(self, category: DatasetSplit) -> Union[TrainDataset, TestDataset]:
-        self.data = load_dataset(self.path, self.name)
         if self.is_transformed == False:
+            self.data = load_dataset(self.path, self.name)
             if self.shuffle_first:
                 logger.log("⚠️ Shuffling Data", level=logger.levels.TWO)
                 self.data = self.data.shuffle(Const.seed)


### PR DESCRIPTION
If you called .load() with .train and then with .test before, it didn't apply the transformations/conversion to pandas, and loaded the raw data.

it wasn't an issue, because we always created a new object, but will be probably at some point!